### PR TITLE
chore: integrate and refine design skills

### DIFF
--- a/.opencode/skill/design-loop/SKILL.md
+++ b/.opencode/skill/design-loop/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: design-loop
-description: "Iterative visual design refinement using vision capability. Implement, screenshot, see, refine, repeat. Use when crafting or improving visual design with eyes-on verification."
+description: "Iterative visual design refinement. Implement, capture, see with vision, assess, refine, repeat. The recursive loop where craft meets sight."
 ---
 
 # Design Loop Skill
 
 **Purpose:** Iteratively refine visual design by implementing changes, capturing screenshots, *actually looking* at them with vision, and making informed refinements. The loop continues until the design achieves the intended vision.
+
+**Builds on:** **web-design** (aesthetic vision + tokens) and **screenshot** (capture procedure)
 
 ---
 
@@ -25,14 +27,16 @@ description: "Iterative visual design refinement using vision capability. Implem
 └─────────────────────────────────────────────────────────┘
 ```
 
-1. **VISION** - Define or refine the aesthetic intention
-2. **IMPLEMENT** - Write the code to realize that vision
-3. **CAPTURE** - Screenshot the result
-4. **SEE** - Actually look at the screenshot with vision capability
-5. **ASSESS** - What works? What doesn't? What's missing?
-6. **REFINE** - Adjust the vision or implementation, return to step 2
+| Step | Action |
+|------|--------|
+| **VISION** | Define or refine the aesthetic intention (see **web-design** skill) |
+| **IMPLEMENT** | Write code using semantic tokens |
+| **CAPTURE** | Screenshot the result (see **screenshot** skill) |
+| **SEE** | Actually look at the screenshot with vision capability |
+| **ASSESS** | What works? What doesn't? What's missing? |
+| **REFINE** | Adjust vision or implementation, return to IMPLEMENT |
 
-**The loop exits when:** The visual result matches the aesthetic intention, or the design achieves a quality that surprises even you.
+**Exit when:** The visual matches the intention, or the design achieves a quality that surprises even you.
 
 ---
 
@@ -40,17 +44,12 @@ description: "Iterative visual design refinement using vision capability. Implem
 
 Code is not design. CSS properties are not aesthetics. The only way to know if a design *works* is to **see it**.
 
-Without vision:
-- Guessing at spacing values
-- Hoping colors work together
-- Imagining what animations feel like
-- Assuming typography reads well
-
-With vision:
-- *Seeing* that the spacing is too tight
-- *Noticing* the accent color gets lost
-- *Feeling* the animation is too fast
-- *Reading* the text and sensing the rhythm
+| Without Vision | With Vision |
+|----------------|-------------|
+| Guessing at spacing values | *Seeing* the spacing is too tight |
+| Hoping colors work together | *Noticing* the accent color gets lost |
+| Imagining animations | *Feeling* the animation is too fast |
+| Assuming typography reads well | *Reading* the text and sensing rhythm |
 
 **Vision transforms design from speculation to craft.**
 
@@ -58,26 +57,28 @@ With vision:
 
 ## Procedure
 
-### Phase 1: Setup
+### Setup
 
 Ensure the dev server is running:
 
 ```bash
 bun run dev --host 0.0.0.0 &
 sleep 5
+# Note the port from output (4321 or 4322)
 ```
 
-Note the port (usually 4321 or 4322).
+### The Loop
 
-### Phase 2: The Loop
+#### 1. Implement
 
-#### Step 1: Implement
+Make changes using semantic tokens. Reference **web-design** skill for:
+- Token quick reference
+- Layout patterns
+- Component templates
 
-Make changes to the code. Use semantic tokens (see web-design skill).
+#### 2. Capture
 
-#### Step 2: Capture
-
-Take a screenshot using Puppeteer:
+Take a screenshot:
 
 ```bash
 cat << 'EOF' | bun run -
@@ -90,9 +91,9 @@ const browser = await puppeteer.launch({
 
 const page = await browser.newPage();
 await page.setViewport({ width: 1280, height: 800 });
-await page.goto('http://localhost:4322/', { waitUntil: 'networkidle0' });
+await page.goto('http://localhost:4321/', { waitUntil: 'networkidle0' });
 
-const path = `/tmp/design-loop-${Date.now()}.png`;
+const path = `/tmp/aiandi-${Date.now()}.png`;
 await page.screenshot({ path, fullPage: false });
 
 await browser.close();
@@ -100,25 +101,25 @@ console.log(path);
 EOF
 ```
 
-#### Step 3: See
+For more capture options, see **screenshot** skill.
 
-Read the screenshot with vision:
+#### 3. See
+
+Read the screenshot:
 
 ```
-Read /tmp/design-loop-TIMESTAMP.png
+Read /tmp/aiandi-TIMESTAMP.png
 ```
 
 **Actually look at it.** Not a glance - a studied examination.
 
-#### Step 4: Assess
-
-Ask yourself:
+#### 4. Assess
 
 **Composition**
 - Does the eye flow naturally?
 - Is there clear hierarchy?
 - Does negative space breathe or suffocate?
-- Are elements aligned with intention (or accidentally)?
+- Are elements aligned with intention?
 
 **Typography**
 - Is the text readable at this size?
@@ -130,7 +131,7 @@ Ask yourself:
 - Do the colors create the intended mood?
 - Is there enough contrast?
 - Does the accent color earn its attention?
-- Is the palette cohesive or chaotic?
+- Is the palette cohesive?
 
 **Details**
 - Are borders and shadows serving a purpose?
@@ -144,69 +145,34 @@ Ask yourself:
 - Does it have a point of view?
 - Am I proud of this?
 
-#### Step 5: Refine
+#### 5. Refine
 
-Based on what you see, decide:
+Based on what you see:
 
-- **Adjust implementation** - The vision is right, execution needs work
-- **Evolve vision** - Seeing it revealed something new
-- **Zoom in** - Focus on a specific element that needs attention
-- **Zoom out** - Step back and assess overall composition
+| Decision | When |
+|----------|------|
+| **Adjust implementation** | Vision is right, execution needs work |
+| **Evolve vision** | Seeing it revealed something new |
+| **Zoom in** | Focus on a specific element |
+| **Zoom out** | Assess overall composition |
 
-Return to Step 1.
+Return to step 1.
 
-### Phase 3: Completion
+### Completion
 
 The loop completes when:
 - The visual matches the intention
 - The design achieves unexpected quality
 - Further refinement yields diminishing returns
 
-Clean up screenshots:
+Clean up:
 ```bash
-rm /tmp/design-loop-*.png
+rm /tmp/aiandi-*.png
 ```
 
 ---
 
-## Capture Variants
-
-### Full Page
-```javascript
-await page.screenshot({ path, fullPage: true });
-```
-
-### Specific Viewport (Mobile)
-```javascript
-await page.setViewport({ width: 375, height: 667 });
-```
-
-### Specific Element
-```javascript
-const element = await page.$('.hero');
-await element.screenshot({ path });
-```
-
-### Multiple Pages
-```javascript
-const pages = ['/', '/blog', '/about'];
-for (const p of pages) {
-  await page.goto(`http://localhost:4322${p}`, { waitUntil: 'networkidle0' });
-  await page.screenshot({ path: `/tmp/design-${p.replace('/', '') || 'home'}-${Date.now()}.png` });
-}
-```
-
-### With Interaction State
-```javascript
-await page.hover('.button');
-await page.screenshot({ path });
-```
-
----
-
-## What to Look For
-
-### Common Issues Revealed by Vision
+## Common Issues Revealed by Vision
 
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
@@ -220,41 +186,28 @@ await page.screenshot({ path });
 | Unbalanced | Visual weight off | Redistribute elements |
 | Unfinished | Missing details | Add borders, shadows, states |
 
+---
+
+## Quick Tests
+
 ### The Squint Test
 
-Squint at the screenshot (or blur it mentally). What do you see?
-- Clear shapes and hierarchy = good structure
-- Muddy blob = needs more contrast
-- One dominant element = clear focal point
-- Everything equal = no hierarchy
+Squint at the screenshot (blur it mentally):
+- **Clear shapes and hierarchy** = good structure
+- **Muddy blob** = needs more contrast
+- **One dominant element** = clear focal point
+- **Everything equal** = no hierarchy
 
 ### The 5-Second Test
 
-Look at the screenshot for 5 seconds, look away. What do you remember?
-- Specific elements = those are working
-- Nothing specific = design lacks distinctiveness
-- Wrong things = hierarchy is off
+Look for 5 seconds, look away. What do you remember?
+- **Specific elements** = those are working
+- **Nothing specific** = lacks distinctiveness
+- **Wrong things** = hierarchy is off
 
 ---
 
-## Integration with Other Skills
-
-### web-design skill
-Provides the aesthetic vision and token system. Load it for:
-- Choosing aesthetic direction
-- Token quick reference
-- Layout patterns
-- Anti-patterns to avoid
-
-### screenshot skill
-Provides capture procedure details. Reference for:
-- Full Puppeteer setup
-- Viewport configurations
-- Troubleshooting
-
----
-
-## Example Loop Session
+## Example Session
 
 ```
 LOOP 1:
@@ -267,22 +220,22 @@ LOOP 1:
 LOOP 2:
 - Implement: Bold heading, generous spacing
 - Capture: Screenshot
-- See: Better hierarchy, but accent color on "between minds" doesn't pop
-- Assess: Amber on dark gray needs more saturation or brightness
+- See: Better hierarchy, but accent color doesn't pop
+- Assess: Amber on dark gray needs more saturation
 - Refine: Adjust accent color in theme
 
 LOOP 3:
 - Implement: Brighter accent color
 - Capture: Screenshot
-- See: Accent pops now, but feels disconnected from rest of page
-- Assess: Need to echo the accent elsewhere to create cohesion
-- Refine: Add accent to border element in cards section
+- See: Accent pops now, but feels disconnected
+- Assess: Need to echo accent elsewhere for cohesion
+- Refine: Add accent border to cards section
 
 LOOP 4:
 - Implement: Accent border on cards
 - Capture: Screenshot
-- See: Cohesive! The accent creates a visual thread. Cards feel inviting.
-- Assess: Ready. Design has clear hierarchy, distinctive color use, rhythm.
+- See: Cohesive! Accent creates visual thread. Cards inviting.
+- Assess: Ready. Clear hierarchy, distinctive color, rhythm.
 - Complete: Clean up, commit changes.
 ```
 
@@ -292,9 +245,9 @@ LOOP 4:
 
 **You are not debugging. You are designing.**
 
-Each loop is not about fixing bugs - it's about refinement toward an aesthetic vision. The screenshot is not a test result - it's a canvas for evaluation.
+Each loop is refinement toward aesthetic vision, not bug fixing. The screenshot is a canvas for evaluation, not a test result.
 
-Trust your eyes. They see things that code cannot express:
+Trust your eyes. They see what code cannot express:
 - Rhythm
 - Balance
 - Tension
@@ -305,7 +258,7 @@ Trust your eyes. They see things that code cannot express:
 
 ---
 
-## When to Use This Skill
+## When to Use
 
 - Creating new pages or components
 - Refining existing designs
@@ -313,6 +266,15 @@ Trust your eyes. They see things that code cannot express:
 - Responsive design verification
 - Before committing visual changes
 - When something "feels off" but you can't articulate why
+
+---
+
+## Related Skills
+
+| Skill | Provides |
+|-------|----------|
+| **web-design** | Aesthetic vision, token system, layout patterns, anti-patterns |
+| **screenshot** | Capture procedure, viewport options, troubleshooting |
 
 ---
 

--- a/.opencode/skill/screenshot/SKILL.md
+++ b/.opencode/skill/screenshot/SKILL.md
@@ -1,45 +1,31 @@
 ---
 name: screenshot
-description: "Take screenshots of the aiandi.dev website. Start dev server, capture pages with Puppeteer, return paths. Use when visual verification or documentation needed."
+description: "Capture screenshots of aiandi.dev for visual verification. Puppeteer-based, outputs to /tmp. Foundation for the design-loop skill."
 ---
 
 # Screenshot Skill
 
-**Purpose:** Capture screenshots of the blog for visual verification, documentation, or debugging.
+**Purpose:** Capture screenshots of the blog for visual verification, documentation, or as part of the design-loop refinement process.
 
 ---
 
 ## When to Use
 
-- Visual verification of changes before commit/deploy
-- Documenting UI states for discussion
-- Debugging layout or styling issues
-- Capturing before/after comparisons
+- **Standalone**: Quick visual verification before commit
+- **With design-loop**: Iterative design refinement (see design-loop skill)
+- **Documentation**: Capturing UI states for discussion
+- **Debugging**: Layout or styling issues
 
 ---
 
-## Prerequisites
-
-This project has Puppeteer installed (`puppeteer@24.35.0`). No additional setup required.
-
----
-
-## Procedure
-
-### 1. Start the Dev Server (if not running)
+## Quick Start
 
 ```bash
+# 1. Ensure dev server is running
 bun run dev --host 0.0.0.0 &
-sleep 8
-```
+sleep 5
 
-**Note:** The server may use port 4321 or 4322 if 4321 is occupied. Check the output for the actual port.
-
-### 2. Take Screenshot with Puppeteer
-
-Create a temporary screenshot in `/tmp` (auto-cleaned by system):
-
-```bash
+# 2. Capture screenshot
 cat << 'EOF' | bun run -
 import puppeteer from 'puppeteer';
 
@@ -51,37 +37,31 @@ const browser = await puppeteer.launch({
 const page = await browser.newPage();
 await page.setViewport({ width: 1280, height: 800 });
 
-// Change URL path as needed (/, /blog, /about, /blog/post-slug)
-await page.goto('http://localhost:4322/', { waitUntil: 'networkidle0' });
+// Note: Check server output for actual port (4321 or 4322)
+await page.goto('http://localhost:4321/', { waitUntil: 'networkidle0' });
 
-// Use /tmp for auto-cleanup
-const path = `/tmp/aiandi-screenshot-${Date.now()}.png`;
+const path = `/tmp/aiandi-${Date.now()}.png`;
 await page.screenshot({ path, fullPage: false });
 
 await browser.close();
-console.log(`Screenshot saved to ${path}`);
+console.log(path);
 EOF
-```
 
-### 3. Read the Screenshot
-
-Use the Read tool to view the screenshot:
-
-```
-Read /tmp/aiandi-screenshot-TIMESTAMP.png
+# 3. View with Read tool
+# Read /tmp/aiandi-TIMESTAMP.png
 ```
 
 ---
 
-## Configuration Options
+## Configuration
 
 ### Viewport Sizes
 
-| Device | Width | Height |
-|--------|-------|--------|
-| Desktop | 1280 | 800 |
-| Tablet | 768 | 1024 |
-| Mobile | 375 | 667 |
+| Device | Width | Height | Use Case |
+|--------|-------|--------|----------|
+| Desktop | 1280 | 800 | Default, most common |
+| Tablet | 768 | 1024 | Responsive testing |
+| Mobile | 375 | 667 | Mobile-first verification |
 
 ### Screenshot Options
 
@@ -89,12 +69,20 @@ Read /tmp/aiandi-screenshot-TIMESTAMP.png
 // Full page (scrolls entire content)
 await page.screenshot({ path, fullPage: true });
 
-// Specific element only
+// Specific element
 const element = await page.$('.hero');
 await element.screenshot({ path });
 
-// With transparency (PNG only)
+// With transparency
 await page.screenshot({ path, omitBackground: true });
+
+// After hover state
+await page.hover('.button');
+await page.screenshot({ path });
+
+// After waiting for animation
+await page.waitForTimeout(300);
+await page.screenshot({ path });
 ```
 
 ### Common Pages
@@ -104,50 +92,45 @@ await page.screenshot({ path, omitBackground: true });
 | Home | `/` |
 | Blog index | `/blog` |
 | About | `/about` |
-| Specific post | `/blog/[slug]` |
+| Blog post | `/blog/[slug]` |
 
 ---
 
-## Complete Example: Multiple Screenshots
+## Multiple Screenshots
 
-```bash
-cat << 'EOF' | bun run -
-import puppeteer from 'puppeteer';
-
+```javascript
 const browser = await puppeteer.launch({
   headless: true,
   args: ['--no-sandbox', '--disable-setuid-sandbox']
 });
 
 const page = await browser.newPage();
-const timestamp = Date.now();
+const ts = Date.now();
 
-const pages = [
+const routes = [
   { path: '/', name: 'home' },
   { path: '/blog', name: 'blog' },
   { path: '/about', name: 'about' }
 ];
 
-for (const { path, name } of pages) {
+for (const { path, name } of routes) {
   await page.setViewport({ width: 1280, height: 800 });
-  await page.goto(`http://localhost:4322${path}`, { waitUntil: 'networkidle0' });
-  const filepath = `/tmp/aiandi-${name}-${timestamp}.png`;
-  await page.screenshot({ path: filepath, fullPage: false });
-  console.log(`Saved: ${filepath}`);
+  await page.goto(`http://localhost:4321${path}`, { waitUntil: 'networkidle0' });
+  await page.screenshot({ path: `/tmp/aiandi-${name}-${ts}.png` });
+  console.log(`Captured: ${name}`);
 }
 
 await browser.close();
-EOF
 ```
 
 ---
 
 ## Cleanup
 
-Screenshots in `/tmp` are automatically cleaned by the system. For immediate cleanup:
+Screenshots in `/tmp` auto-clean on system restart. For immediate cleanup:
 
 ```bash
-rm /tmp/aiandi-screenshot-*.png
+rm /tmp/aiandi-*.png
 ```
 
 ---
@@ -156,19 +139,29 @@ rm /tmp/aiandi-screenshot-*.png
 
 | Issue | Solution |
 |-------|----------|
-| Port 4321 in use | Check server output for actual port (often 4322) |
-| Blank screenshot | Increase `sleep` time or use `waitUntil: 'networkidle0'` |
+| Port in use | Check server output for actual port (4321 or 4322) |
+| Blank screenshot | Increase sleep time or use `waitUntil: 'networkidle0'` |
 | Browser launch fails | Ensure `--no-sandbox` flag is included |
-| Element not found | Wait for selector: `await page.waitForSelector('.element')` |
+| Element not found | Use `await page.waitForSelector('.element')` |
+| Stale content | Add `await page.reload()` before capture |
 
 ---
 
 ## Important Notes
 
-- **Always use `/tmp`** for screenshots to avoid cluttering the repo
-- **Never commit screenshots** to the repository
-- The dev server runs in background (`&`); kill it when done if needed: `pkill -f "astro dev"`
-- Screenshots are for verification only; delete after use or let `/tmp` auto-clean
+- **Always use `/tmp`** - Never save screenshots in the repo
+- **Never commit screenshots** - They're for verification only
+- **Check the port** - Server may use 4321 or 4322
+- **Kill server when done** - `pkill -f "astro dev"` if needed
+
+---
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|--------------|
+| **design-loop** | Uses screenshot as part of iterative refinement |
+| **web-design** | Provides the design system for what you're capturing |
 
 ---
 

--- a/.opencode/skill/web-design/SKILL.md
+++ b/.opencode/skill/web-design/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: web-design
-description: "Create distinctive, production-grade layouts for aiandi.dev. Combines bold aesthetic vision with our semantic token system. Use when designing pages, components, or visual treatments."
+description: "Create distinctive, production-grade layouts for aiandi.dev. Bold aesthetic vision + semantic token system. Use when designing pages, components, or visual treatments."
 ---
 
 # Web Design Skill
 
 **Purpose:** Create distinctive, production-grade interfaces for aiandi.dev that avoid generic "AI slop" aesthetics while leveraging our semantic token architecture.
+
+**Related skills:** Use **design-loop** for iterative refinement with visual verification. Use **screenshot** for one-off captures.
 
 ---
 
@@ -336,7 +338,7 @@ Every interactive element needs three states:
 3. **Check existing patterns** - Reuse before creating
 4. **Implement with precision** - Execute the vision completely
 5. **Include all states** - Default, hover, focus, disabled
-6. **Verify visually** - Use screenshot skill to capture result
+6. **Verify visually** - Use **design-loop** skill for iterative refinement
 
 ### Component Template
 
@@ -366,17 +368,6 @@ const variants = {
 
 ---
 
-### Visual Verification
-
-Use the screenshot skill after making changes:
-
-```bash
-bun run dev --host 0.0.0.0 &
-# See screenshot skill for capture procedure
-```
-
----
-
 ## The Standard
 
 **Match implementation complexity to aesthetic vision:**
@@ -387,6 +378,15 @@ bun run dev --host 0.0.0.0 &
 **The question to ask:** Is this design **distinctive**? Would someone remember it? Does it have a clear point of view?
 
 Generic is the enemy. Safe is forgettable. Commit to a direction and execute with conviction.
+
+---
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| **design-loop** | Iterative refinement with visual verification |
+| **screenshot** | One-off captures for verification or documentation |
 
 ---
 


### PR DESCRIPTION
## Summary

Refines all three design skills to work as a cohesive system with proper integration.

### Changes

**screenshot skill:**
- Consistent file naming prefix (`aiandi-*`)
- Flexible port handling (notes that server may use 4321 or 4322)
- Cleaner quick-start section
- Added Related Skills section

**web-design skill:**
- Added explicit cross-references to design-loop and screenshot at top
- Clarified when to use each related skill
- Process section now points to design-loop for visual verification

**design-loop skill:**
- References screenshot skill instead of duplicating Puppeteer code
- Consistent file naming with screenshot skill
- Clearer step descriptions with table format
- Related Skills section shows what each skill provides

### The System

```
screenshot ──────► Foundation for capture
     │
     ▼
web-design ──────► Aesthetic vision + technical execution
     │
     ▼
design-loop ─────► Iterative refinement using both
```

All three skills now cross-reference each other appropriately, use consistent patterns, and form a unified design workflow.