### PR TITLE
Refine homepage copy and add nuclear design option

### DIFF
--- a/.opencode/skill/design-loop/SKILL.md
+++ b/.opencode/skill/design-loop/SKILL.md
@@ -29,6 +29,8 @@ description: "Iterative visual design refinement. Implement, capture, see with v
 │     │                                  ▼                │
 │   REFINE ◄──────────────────────── ASSESS               │
 │                                                         │
+│   NUCLEAR ◄──── Radical departure if derivative         │
+│                                                         │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -40,8 +42,32 @@ description: "Iterative visual design refinement. Implement, capture, see with v
 | **SEE** | Actually look at the screenshot with vision capability |
 | **ASSESS** | What works? What doesn't? What's missing? |
 | **REFINE** | Adjust vision or implementation, return to IMPLEMENT |
+| **NUCLEAR** | Throw it all away and start fresh if it's derivative |
 
 **Exit when:** The visual matches the intention, or the design achieves a quality that surprises even you.
+
+---
+
+## Nuclear Option: Starting Fresh
+
+**Trigger the nuclear option when:**
+- The design feels derivative or safe
+- Incremental changes aren't creating distinctiveness
+- You're tweaking instead of reimagining
+- The user explicitly asks for "nuclear" or "from scratch"
+- You see the design and think "this could be any blog"
+
+**Nuclear procedure:**
+1. **Acknowledge the reset** - "This needs a radical departure, not refinement."
+2. **Choose a completely different aesthetic** from web-design palette
+3. **Ignore existing layout** - Don't look at current code for "inspiration"
+4. **Implement bold vision** - Typography, layout, color all change
+5. **Capture and assess** - Did we break free of the derivative trap?
+
+**Example triggers:**
+- User: "This feels too safe, go nuclear"
+- User: "Start fresh, ignore what we have"
+- You assess: "This is incrementally better but still generic"
 
 ---
 
@@ -214,7 +240,9 @@ Look for 5 seconds, look away. What do you remember?
 
 ---
 
-## Example Session
+## Example Sessions
+
+### Example 1: Refinement (Incremental)
 
 ```
 LOOP 1:
@@ -244,6 +272,68 @@ LOOP 4:
 - See: Cohesive! Accent creates visual thread. Cards inviting.
 - Assess: Ready. Clear hierarchy, distinctive color, rhythm.
 - Complete: Clean up, commit changes.
+```
+
+### Example 2: Nuclear Option (Radical Departure)
+
+```
+LOOP 1:
+- Implement: Standard centered hero, card grid below
+- Capture: Screenshot
+- See: This is... fine. Professional. Forgettable.
+- Assess: Every tech blog looks like this. NUCLEAR OPTION.
+
+NUCLEAR RESET:
+- Vision: Punk zine meets scientific journal
+- Implement: 
+  * Asymmetric layout - hero pushed hard left
+  * Massive monospace headline (terminal aesthetic)
+  * Remove all color except single accent on links
+  * Add diagonal borders, angles instead of cards
+  * Make typography uncomfortably large
+
+LOOP 2:
+- Capture: Screenshot
+- See: Whoa. Aggressive. Memorable. Polarizing?
+- Assess: TOO aggressive. Need some warmth back.
+- Refine: Add subtle warmth to background, soften one edge
+
+LOOP 3:
+- Capture: Screenshot
+- See: Yes! Distinctive without being hostile.
+- Assess: Would remember this. Has a point of view.
+- Complete: This breaks the mold while staying accessible.
+```
+
+### Example 3: Recognizing Derivative Work
+
+```
+LOOP 1:
+- Implement: Clean dark mode, amber accents, generous spacing
+- Capture: Screenshot
+- See: Nice! Professional! Like... every other dark mode blog?
+- Assess: STOP. This is derivative. What's the actual vision here?
+
+RETHINK:
+- Not "dark mode blog" - that's a template
+- Not "warm accents" - that's safe
+- What's ACTUALLY distinctive about this content?
+  * Ancient patterns in new tools
+  * Recursive collaboration
+  * Workbench, not portfolio
+
+NEW VISION: Museum placard meets lab notebook
+- White/cream dominant (invert the dark mode expectation)
+- Monochrome except red for "danger/important"
+- Grid system visible as subtle lines
+- Typography: mix of clinical sans + handwritten annotations
+- Cards become "specimens" with catalog numbers
+
+LOOP 2:
+- Implement: Complete visual inversion
+- Capture: Screenshot
+- See: COMPLETELY different. Unexpected. Museum-like precision.
+- Assess: This matches the "workbench" vision better than dark mode ever did.
 ```
 
 ---

--- a/.opencode/skill/web-design/SKILL.md
+++ b/.opencode/skill/web-design/SKILL.md
@@ -23,7 +23,9 @@ Before touching code, understand context and commit to a **BOLD** aesthetic dire
 - **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
 - **Constraints**: Accessibility, performance, our token system
 
-**Aesthetic Palette** (pick one, execute with precision):
+**⚠️ WARNING:** If you're about to make "incremental improvements" to an existing design, STOP. Consider whether this needs a radical departure instead. Safe refinements create forgettable design.
+
+**Aesthetic Palette** (pick one, execute with conviction):
 
 | Direction | Character |
 |-----------|-----------|
@@ -37,6 +39,39 @@ Before touching code, understand context and commit to a **BOLD** aesthetic dire
 | Brutalist/raw | Exposed structure. Aggressive honesty. |
 
 **CRITICAL**: Bold maximalism and refined minimalism both work. The key is **intentionality**, not intensity. Pick a direction and execute it with conviction.
+
+---
+
+### Creative Departure Prompts
+
+When you need to break free from derivative thinking, ask:
+
+**Inversion Questions:**
+- What if the most important thing was SMALL instead of large?
+- What if we used NO color except one?
+- What if there was NO hero section, just immediate content?
+- What if typography was PLAYFUL instead of serious?
+
+**Constraint Forcing:**
+- Design with only 2 font sizes
+- Use only vertical or only horizontal rhythm (not both)
+- Make ONE element absurdly oversized
+- Ban all rounded corners OR ban all sharp corners
+
+**Medium Shifts:**
+- What if this was a printed zine?
+- What if this was a terminal interface?
+- What if this was handwritten notes?
+- What if this was a museum placard?
+
+**Unexpected References:**
+- Scientific journals (data-dense, precise)
+- Art gallery walls (space, curation, labels)
+- Punk zines (raw, urgent, collage)
+- Old programming books (monospace, diagrams)
+- Brutalist architecture (exposed structure, no decoration)
+
+**The test:** If your first idea is what everyone else would do, throw it away and force yourself to come up with 3 more alternatives before implementing.
 
 ---
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,4 +2,4 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 export const SITE_TITLE = 'AI and I';
-export const SITE_DESCRIPTION = 'A 56-year-old learning to code through AI collaboration. Figuring things out in public, finding ancient patterns in new technology.';
+export const SITE_DESCRIPTION = "Exploring what emerges when you stop prompting and start collaborating. Field notes from the experiment.";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,12 +22,12 @@ const [featuredPost, ...olderPosts] = posts;
 	<body class="min-h-screen flex flex-col bg-background text-text-primary font-body antialiased">
 		<Header />
 		
-		<main class="flex-1 max-w-4xl mx-auto px-6 py-16 md:py-24 w-full">
+		<main class="flex-1 max-w-4xl mx-auto px-6 py-20 md:py-32 w-full">
 			<!-- Hero Section -->
-			<section class="mb-24 md:mb-32">
-				<h1 class="font-heading text-6xl md:text-8xl leading-[1.05] mb-10 tracking-[-0.025em] balance-text">
-					Exploring the <span class="text-accent">collaboration</span><br />
-					between minds
+			<section class="mb-32 md:mb-40">
+				<h1 class="font-heading text-6xl md:text-8xl leading-[1.05] mb-12 tracking-[-0.025em] balance-text">
+					Ancient patterns in<br />
+					<span class="text-accent">new tools</span>
 				</h1>
 				<p class="text-xl md:text-2xl leading-[1.7] text-text-secondary max-w-[55ch]">
 					{SITE_DESCRIPTION}
@@ -36,8 +36,8 @@ const [featuredPost, ...olderPosts] = posts;
 
 			<!-- Featured Post -->
 			{featuredPost && (
-				<section class="mb-20">
-					<div class="flex items-center gap-4 mb-8">
+				<section class="mb-24">
+					<div class="flex items-center gap-4 mb-10">
 						<h2 class="font-heading text-xs uppercase tracking-[0.15em] text-accent font-medium">
 							Latest
 						</h2>
@@ -47,22 +47,22 @@ const [featuredPost, ...olderPosts] = posts;
 					<article class="group">
 						<a 
 							href={`/blog/${featuredPost.id}/`}
-							class="block bg-surface rounded-md p-8 md:p-12 border-l-4 border-accent hover:border-accent-hover transition-all duration-normal hover:shadow-lg hover:shadow-accent/5"
+							class="block bg-surface rounded-lg p-10 md:p-14 border-l-[6px] border-accent hover:border-accent-hover transition-all duration-normal hover:shadow-xl hover:shadow-accent/10 hover:-translate-y-0.5"
 						>
-							<div class="flex flex-col md:flex-row md:items-baseline md:justify-between gap-3 mb-5">
-								<h3 class="font-heading text-3xl md:text-4xl font-semibold leading-[1.2] tracking-[-0.015em] group-hover:text-accent transition-colors duration-normal balance-text">
+							<div class="flex flex-col gap-5 mb-6">
+								<h3 class="font-heading text-3xl md:text-5xl font-bold leading-[1.15] tracking-[-0.02em] group-hover:text-accent transition-colors duration-normal balance-text">
 									{featuredPost.data.title}
 								</h3>
-								<time 
-									datetime={featuredPost.data.pubDate.toISOString()}
-									class="font-mono text-xs tracking-wide text-text-muted whitespace-nowrap uppercase"
-								>
-									<FormattedDate date={featuredPost.data.pubDate} />
-								</time>
+								<p class="text-lg md:text-xl leading-[1.75] text-text-secondary/90">
+									{featuredPost.data.description}
+								</p>
 							</div>
-							<p class="text-lg md:text-xl leading-[1.7] text-text-secondary max-w-[65ch]">
-								{featuredPost.data.description}
-							</p>
+							<time 
+								datetime={featuredPost.data.pubDate.toISOString()}
+								class="font-mono text-xs tracking-wide text-text-muted uppercase inline-block"
+							>
+								<FormattedDate date={featuredPost.data.pubDate} />
+							</time>
 						</a>
 					</article>
 				</section>
@@ -71,19 +71,19 @@ const [featuredPost, ...olderPosts] = posts;
 			<!-- Archive -->
 			{olderPosts.length > 0 && (
 				<section>
-					<div class="flex items-center gap-4 mb-10">
-						<h2 class="font-heading text-xs uppercase tracking-[0.15em] text-text-muted font-medium">
-							Archive
+					<div class="flex items-center gap-4 mb-12">
+						<h2 class="font-heading text-xs uppercase tracking-[0.15em] text-accent/70 font-medium">
+							Earlier Work
 						</h2>
-						<div class="flex-1 h-px bg-gradient-to-r from-border/50 to-transparent"></div>
+						<div class="flex-1 h-px bg-gradient-to-r from-accent/20 to-transparent"></div>
 					</div>
 					
-					<ul class="space-y-10">
+					<ul class="space-y-1">
 						{olderPosts.map((post) => (
 							<li class="group">
 								<a 
 									href={`/blog/${post.id}/`}
-									class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-8 py-5 border-l-2 border-transparent hover:border-accent pl-5 -ml-5 transition-all duration-normal"
+									class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-8 py-6 border-l-[4px] border-transparent hover:border-accent hover:bg-surface/40 pl-6 -ml-6 transition-all duration-normal rounded-r"
 								>
 									<h3 class="font-heading text-xl md:text-2xl leading-[1.3] tracking-[-0.01em] group-hover:text-accent transition-colors flex-1 balance-text">
 										{post.data.title}


### PR DESCRIPTION
## Summary

- Improved homepage positioning to focus on work rather than age/experience
- Enhanced design-loop and web-design skills with nuclear option for radical departures
- Better visual hierarchy and spacing throughout homepage

## Homepage Copy Changes

**Before:**
- "At 56, I'm learning to code..." (defensive, age-focused)
- "Exploring the collaboration between minds" (generic)

**After:**
- "Ancient patterns in new tools" (distinctive, intellectually substantive)
- "Exploring what emerges when you stop prompting and start collaborating"
- Focuses on the work and discoveries, not personal positioning

## Design Improvements

- Larger featured card (5xl title, 6px border, lift on hover)
- More generous spacing (mb-32/40 vs mb-24/32)
- "Earlier Work" vs "Archive" (more invitational)
- Stronger hover states with background tint

## Design Skill Enhancements

Added "nuclear option" to design-loop skill:
- Explicit triggers for radical design departures
- Examples of incremental vs radical iteration patterns
- Creative departure prompts (inversion questions, constraint forcing)
- Warning against derivative, safe refinements

Added creative prompts to web-design skill:
- Inversion questions to break default thinking
- Constraint forcing techniques
- Unexpected reference points (zines, terminals, museums)
- Medium shift exercises

These enhancements enable both refinement mode (when vision is right) and nuclear mode (when design is derivative).